### PR TITLE
Added wireguard symlink

### DIFF
--- a/images/wireguard_False.png
+++ b/images/wireguard_False.png
@@ -1,0 +1,1 @@
+vpn_False.png

--- a/images/wireguard_True.png
+++ b/images/wireguard_True.png
@@ -1,0 +1,1 @@
+vpn_True.png


### PR DESCRIPTION
I added png symlinks for wireguard vpn connections. I already tested it and it works fine.
Here is how a wireguard connection looks like in nmcli:
```shell
MyWireguard: connected to MyWireguardVPN
        "MyWireguard"
        wireguard, sw, mtu 1420
        inet4 100.64.0.2/24
        route4 100.64.0.0/24 metric 50
```